### PR TITLE
IPv6 Support for streameye server

### DIFF
--- a/client.h
+++ b/client.h
@@ -22,7 +22,7 @@
 
 typedef struct {
     int             stream_fd;
-    char            addr[INET_ADDRSTRLEN];
+    char            addr[INET6_ADDRSTRLEN];
     int             port;
     char            method[10];
     char            http_ver[10];

--- a/common.h
+++ b/common.h
@@ -24,9 +24,9 @@
 #define INFO(fmt, ...)                  if (log_level >= 1) fprintf(stderr, "%s: INFO : " fmt "\n", str_timestamp(), ##__VA_ARGS__)
 #define ERROR(fmt, ...)                 if (log_level >= 0) fprintf(stderr, "%s: ERROR: " fmt "\n", str_timestamp(), ##__VA_ARGS__)
 #define ERRNO(msg)                      ERROR("%s: %s", msg, strerror(errno))
-#define DEBUG_CLIENT(client, fmt, ...)  DEBUG("%s:%d: " fmt, client->addr, client->port, ##__VA_ARGS__)
-#define INFO_CLIENT(client, fmt, ...)   INFO("%s:%d: " fmt, client->addr, client->port, ##__VA_ARGS__)
-#define ERROR_CLIENT(client, fmt, ...)  ERROR("%s:%d: " fmt, client->addr, client->port, ##__VA_ARGS__)
+#define DEBUG_CLIENT(client, fmt, ...)  DEBUG("[%s]:%d: " fmt, client->addr, client->port, ##__VA_ARGS__)
+#define INFO_CLIENT(client, fmt, ...)   INFO("[%s]:%d: " fmt, client->addr, client->port, ##__VA_ARGS__)
+#define ERROR_CLIENT(client, fmt, ...)  ERROR("[%s]:%d: " fmt, client->addr, client->port, ##__VA_ARGS__)
 #define ERRNO_CLIENT(client, msg)       ERROR_CLIENT(client, "%s: %s", msg, strerror(errno))
 
 #define MIN(a, b)                       ((a) < (b) ? (a) : (b))


### PR DESCRIPTION
I ran into an issue with streameye, where I could view the streams in a normal web browser, but adding them via hostname to motion wasn't working. Further investigation showed that adding the stream by IPv4 address did work, but that adding by hostname wasn't working because motion supports IPv6, and wasn't falling back to IPv4 as we web browser did.

I therefore present a trivial patch to support IPv6. If I really wanted to be fancy, I'd have added a command-line option to allow specifying IPv4 or IPv6, but it's simpler to just leave that to iptables or perhaps another patch.