### PR TITLE
Python 3 support for raspimjpeg.py

### DIFF
--- a/extras/raspimjpeg.py
+++ b/extras/raspimjpeg.py
@@ -299,10 +299,14 @@ def init_camera():
 
     logging.debug('camera initialized')
 
+if sys.version_info.major >= 3:
+    my_stdout = sys.stdout.buffer
+else:
+    my_stdout = sys.stdout
 
 def streams_iter():
     while running:
-        yield sys.stdout
+        yield my_stdout
         sys.stdout.flush()
 
 


### PR DESCRIPTION
raspimjpeg does not work under python 3 because the picamera encoder
expects the output to accept bytes, not str. This is easy enough to fix,
just pass sys.stdout.buffer instead of sys.stdout.