### PR TITLE
Add pthread.h to common.h to fix build on OS X / macOS

### DIFF
--- a/common.h
+++ b/common.h
@@ -20,6 +20,8 @@
 #ifndef __COMMON_H
 #define __COMMON_H
 
+#include <pthread.h>
+
 #define DEBUG(fmt, ...)                 if (log_level >= 2) fprintf(stderr, "%s: DEBUG: " fmt "\n", str_timestamp(), ##__VA_ARGS__)
 #define INFO(fmt, ...)                  if (log_level >= 1) fprintf(stderr, "%s: INFO : " fmt "\n", str_timestamp(), ##__VA_ARGS__)
 #define ERROR(fmt, ...)                 if (log_level >= 0) fprintf(stderr, "%s: ERROR: " fmt "\n", str_timestamp(), ##__VA_ARGS__)


### PR DESCRIPTION
Common.h is used in auth.c, which does not have pthread included, and hence `pthread_mutex_t` is unknown when compiling.

Therefore I get the following error compiling on OS X. Adding an include directive fixes this.

Although including headers within headers isn't ideal, I think it is justified in this case?

```cc -Wall -pthread -O2 -D_GNU_SOURCE -c -o auth.o auth.c
In file included from auth.c:26:
./common.h:40:8: error: unknown type name 'pthread_cond_t'; did you mean 'pthread_attr_t'?
extern pthread_cond_t                   jpeg_cond;
       ^~~~~~~~~~~~~~
       pthread_attr_t
/Library/Developer/CommandLineTools/SDKs/MacOSX10.14.sdk/usr/include/sys/_pthread/_pthread_attr_t.h:31:33: note: 'pthread_attr_t'
      declared here
typedef __darwin_pthread_attr_t pthread_attr_t;
                                ^
In file included from auth.c:26:
./common.h:41:8: error: unknown type name 'pthread_mutex_t'; did you mean 'pthread_attr_t'?
extern pthread_mutex_t                  jpeg_mutex;
       ^~~~~~~~~~~~~~~
       pthread_attr_t
/Library/Developer/CommandLineTools/SDKs/MacOSX10.14.sdk/usr/include/sys/_pthread/_pthread_attr_t.h:31:33: note: 'pthread_attr_t'
      declared here
typedef __darwin_pthread_attr_t pthread_attr_t;
                                ^
2 errors generated.
make: *** [auth.o] Error 1
The terminal process terminated with exit code: 2
```