### PR TITLE
Fix logging error preventing from using the colfx option

### DIFF
--- a/extras/raspimjpeg.py
+++ b/extras/raspimjpeg.py
@@ -290,7 +290,7 @@ def init_camera():
         camera.image_effect = options.imxfx
 
     if options.colfx is not None:
-        logging.debug('using color effect = %s' % options.colfx)
+        logging.debug('using color effect = %s' % (options.colfx,))
         camera.color_effects = options.colfx
 
     if options.preview:


### PR DESCRIPTION
Wanted to switch color to B&W and encountered some python error while converting tuple to string
This fix the error, allowing to use the colfx option