### PR TITLE
Fix default for stereo mode

### DIFF
--- a/extras/raspimjpeg.py
+++ b/extras/raspimjpeg.py
@@ -72,7 +72,7 @@ def parse_options():
     parser.add_argument('-q', '--quality', help='jpeg quality factor (1 to 100, defaults to 50)',
             type=int, dest='quality', default=50)
     parser.add_argument('-3d', '--stereo', help='Stereoscopic mode (none, side-by-side, top-bottom)',
-            type=str, dest='stereo_mode', default=None)
+            type=str, dest='stereo_mode', default='none')
 
     parser.add_argument('-p', '--preview', help='enable camera preview to HDMI port',
             action='store_true', dest='preview', default=False)


### PR DESCRIPTION
Addresses comment from [here](https://github.com/ccrisan/streameye/pull/30#issuecomment-815375848).

Broken default

```bash
root@gugelhupf-agent-1:~# raspimjpeg.py -w 640 -h 480 -r 15
2021-04-07 18:12:46:  INFO: raspimjpeg.py 0.8
2021-04-07 18:12:46:  INFO: hello!
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/dist-packages/picamera/camera.py", line 423, in __init__
    stereo_mode = self.STEREO_MODES[stereo_mode]
KeyError: None

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/bin/raspimjpeg.py", line 330, in <module>
    init_camera()
  File "/usr/local/bin/raspimjpeg.py", line 226, in init_camera
    camera = picamera.PiCamera(resolution=(options.width, options.height), stereo_mode=options.stereo_mode)
  File "/usr/local/lib/python3.7/dist-packages/picamera/camera.py", line 425, in __init__
    raise PiCameraValueError('Invalid stereo mode: %s' % stereo_mode)
picamera.exc.PiCameraValueError: Invalid stereo mode: None
root@gugelhupf-agent-1:~# pip list
Package    Version
---------- -------
picamera   1.13
pip        21.0.1
setuptools 54.2.0
wheel      0.36.2
```

Setting it explicitly works:

```bash
raspimjpeg.py -w 640 -h 480 -r 15 --stereo none
```
